### PR TITLE
Kaushal/load multiple sounds

### DIFF
--- a/JuceLibraryCode/modules/SFZero/sfzero/SFZSound.cpp
+++ b/JuceLibraryCode/modules/SFZero/sfzero/SFZSound.cpp
@@ -34,7 +34,7 @@ bool sfzero::Sound::appliesToNote(int /*midiNoteNumber*/)
 
 bool sfzero::Sound::appliesToChannel(int midiChannel)
 {
-    //std::cout << "sfzero::Sound::appliesToChannel---> input-midi-channel:" << midiChannel << " sound-works-with-channel:" << channel_ <<std::endl;
+    //DBG("sfzero::Sound::appliesToChannel---> input-midi-channel:" << midiChannel << " sound-works-with-channel:" << channel_ );
     if (channel_ == -1)
         return true;
     else

--- a/JuceLibraryCode/modules/SFZero/sfzero/SFZSound.cpp
+++ b/JuceLibraryCode/modules/SFZero/sfzero/SFZSound.cpp
@@ -32,7 +32,19 @@ bool sfzero::Sound::appliesToNote(int /*midiNoteNumber*/)
     return true;
 }
 
-bool sfzero::Sound::appliesToChannel(int /*midiChannel*/) { return true; }
+bool sfzero::Sound::appliesToChannel(int midiChannel)
+{
+    //std::cout << "sfzero::Sound::appliesToChannel---> input-midi-channel:" << midiChannel << " sound-works-with-channel:" << channel_ <<std::endl;
+    if (channel_ == -1)
+        return true;
+    else
+        return midiChannel == channel_;
+}
+
+void sfzero::Sound::setChannelNum(int channelNum) {
+    channel_ = channelNum;
+}
+
 void sfzero::Sound::addRegion(sfzero::Region *region) { regions_.add(region); }
 sfzero::Sample *sfzero::Sound::addSample(juce::String path, juce::String defaultPath)
 {

--- a/JuceLibraryCode/modules/SFZero/sfzero/SFZSound.h
+++ b/JuceLibraryCode/modules/SFZero/sfzero/SFZSound.h
@@ -46,10 +46,15 @@ namespace sfzero
         virtual juce::String subsoundName(int whichSubsound);
         virtual void useSubsound(int whichSubsound);
         virtual int selectedSubsound();
-        
+
+        virtual void setChannelNum(int channelNum);
+
         juce::String dump();
         juce::Array<Region *> &getRegions() { return regions_; }
         juce::File &getFile() { return file_; }
+
+    protected:
+        int channel_ = -1;
         
     private:
         juce::File file_;

--- a/JuceLibraryCode/modules/SFZero/sfzero/SFZSynth.cpp
+++ b/JuceLibraryCode/modules/SFZero/sfzero/SFZSynth.cpp
@@ -24,7 +24,6 @@ void sfzero::Synth::noteOn(int midiChannel, int midiNoteNumber, float velocity)
 
         int group = 0;
         auto *sound = dynamic_cast<sfzero::Sound *>(getSound(s).get());
-        // std::cout << "sfzero::Synth::noteOn--> Sound: " << sound->selectedSubsound() << " -- ";
         if (sound->appliesToNote(midiNoteNumber) && sound->appliesToChannel(midiChannel)) {
             if (sound) {
                 sfzero::Region *region = sound->getRegionFor(midiNoteNumber, midiVelocity);

--- a/JuceLibraryCode/modules/SFZero/sfzero/SFZSynth.cpp
+++ b/JuceLibraryCode/modules/SFZero/sfzero/SFZSynth.cpp
@@ -19,70 +19,73 @@ void sfzero::Synth::noteOn(int midiChannel, int midiNoteNumber, float velocity)
     int midiVelocity = static_cast<int>(velocity * 127);
     
     // First, stop any currently-playing sounds in the group.
-    //*** Currently, this only pays attention to the first matching region.
-    int group = 0;
-    sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>( getSound(0).get() );
 
-    if (sound->appliesToNote (midiNoteNumber) && sound->appliesToChannel (midiChannel)) {
-        if (sound) {
-            sfzero::Region *region = sound->getRegionFor(midiNoteNumber, midiVelocity);
-            if (region) {
-                group = region->group;
+    for (int s=0; s<getNumSounds(); s++) {
+
+        int group = 0;
+        auto *sound = dynamic_cast<sfzero::Sound *>(getSound(s).get());
+        // std::cout << "sfzero::Synth::noteOn--> Sound: " << sound->selectedSubsound() << " -- ";
+        if (sound->appliesToNote(midiNoteNumber) && sound->appliesToChannel(midiChannel)) {
+            if (sound) {
+                sfzero::Region *region = sound->getRegionFor(midiNoteNumber, midiVelocity);
+                if (region) {
+                    group = region->group;
+                }
             }
-        }
-        if (group != 0) {
+            if (group != 0) {
+                for (i = voices.size(); --i >= 0;) {
+                    sfzero::Voice *voice = dynamic_cast<sfzero::Voice *>(voices.getUnchecked(i));
+                    if (voice == nullptr) {
+                        continue;
+                    }
+                    if (voice->getOffBy() == group) {
+                        voice->stopNoteForGroup();
+                    }
+                }
+            }
+
+            // Are any notes playing?  (Needed for first/legato trigger handling.)
+            // Also stop any voices still playing this note.
+            bool anyNotesPlaying = false;
             for (i = voices.size(); --i >= 0;) {
                 sfzero::Voice *voice = dynamic_cast<sfzero::Voice *>(voices.getUnchecked(i));
                 if (voice == nullptr) {
                     continue;
                 }
-                if (voice->getOffBy() == group) {
-                    voice->stopNoteForGroup();
-                }
-            }
-        }
-
-        // Are any notes playing?  (Needed for first/legato trigger handling.)
-        // Also stop any voices still playing this note.
-        bool anyNotesPlaying = false;
-        for (i = voices.size(); --i >= 0;) {
-            sfzero::Voice *voice = dynamic_cast<sfzero::Voice *>(voices.getUnchecked(i));
-            if (voice == nullptr) {
-                continue;
-            }
-            if (voice->isPlayingChannel(midiChannel)) {
-                if (voice->isPlayingNoteDown()) {
-                    if (voice->getCurrentlyPlayingNote() == midiNoteNumber) {
-                        if (!voice->isPlayingOneShot()) {
-                            voice->stopNoteQuick();
+                if (voice->isPlayingChannel(midiChannel)) {
+                    if (voice->isPlayingNoteDown()) {
+                        if (voice->getCurrentlyPlayingNote() == midiNoteNumber) {
+                            if (!voice->isPlayingOneShot()) {
+                                voice->stopNoteQuick();
+                            }
+                        } else {
+                            anyNotesPlaying = true;
                         }
-                    } else {
-                        anyNotesPlaying = true;
                     }
                 }
             }
-        }
 
-        // Play *all* matching regions.
-        sfzero::Region::Trigger trigger = (anyNotesPlaying ? sfzero::Region::legato : sfzero::Region::first);
-        if (sound) {
-            int numRegions = sound->getNumRegions();
-            for (i = 0; i < numRegions; ++i) {
-                sfzero::Region *region = sound->regionAt(i);
-                if (region->matches(midiNoteNumber, midiVelocity, trigger)) {
-                    auto *voice = dynamic_cast<sfzero::Voice *>(findFreeVoice(sound, midiChannel, midiNoteNumber,
-                                                                              isNoteStealingEnabled()));
-                    if (voice) {
-                        voice->setRegion(region);
-                        startVoice(voice, sound, midiChannel, midiNoteNumber, velocity);
+            // Play *all* matching regions.
+            sfzero::Region::Trigger trigger = (anyNotesPlaying ? sfzero::Region::legato : sfzero::Region::first);
+            if (sound) {
+                int numRegions = sound->getNumRegions();
+                for (i = 0; i < numRegions; ++i) {
+                    sfzero::Region *region = sound->regionAt(i);
+                    if (region->matches(midiNoteNumber, midiVelocity, trigger)) {
+                        auto *voice = dynamic_cast<sfzero::Voice *>(findFreeVoice(sound, midiChannel, midiNoteNumber,
+                                                                                  isNoteStealingEnabled()));
+                        if (voice) {
+                            voice->setRegion(region);
+                            startVoice(voice, sound, midiChannel, midiNoteNumber, velocity);
 //                    DBG("noteON: " << midiNoteNumber << " " << midiChannel << " " << velocity);
+                        }
                     }
                 }
             }
+
+            noteVelocities_[midiNoteNumber] = midiVelocity;
+
         }
-
-        noteVelocities_[midiNoteNumber] = midiVelocity;
-
     }
 }
 

--- a/JuceLibraryCode/modules/SFZero/sfzero/SFZSynth.cpp
+++ b/JuceLibraryCode/modules/SFZero/sfzero/SFZSynth.cpp
@@ -22,82 +22,68 @@ void sfzero::Synth::noteOn(int midiChannel, int midiNoteNumber, float velocity)
     //*** Currently, this only pays attention to the first matching region.
     int group = 0;
     sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>( getSound(0).get() );
-    
-    if (sound)
-    {
-        sfzero::Region *region = sound->getRegionFor(midiNoteNumber, midiVelocity);
-        if (region)
-        {
-            group = region->group;
+
+    if (sound->appliesToNote (midiNoteNumber) && sound->appliesToChannel (midiChannel)) {
+        if (sound) {
+            sfzero::Region *region = sound->getRegionFor(midiNoteNumber, midiVelocity);
+            if (region) {
+                group = region->group;
+            }
         }
-    }
-    if (group != 0)
-    {
-        for (i = voices.size(); --i >= 0;)
-        {
+        if (group != 0) {
+            for (i = voices.size(); --i >= 0;) {
+                sfzero::Voice *voice = dynamic_cast<sfzero::Voice *>(voices.getUnchecked(i));
+                if (voice == nullptr) {
+                    continue;
+                }
+                if (voice->getOffBy() == group) {
+                    voice->stopNoteForGroup();
+                }
+            }
+        }
+
+        // Are any notes playing?  (Needed for first/legato trigger handling.)
+        // Also stop any voices still playing this note.
+        bool anyNotesPlaying = false;
+        for (i = voices.size(); --i >= 0;) {
             sfzero::Voice *voice = dynamic_cast<sfzero::Voice *>(voices.getUnchecked(i));
-            if (voice == nullptr)
-            {
+            if (voice == nullptr) {
                 continue;
             }
-            if (voice->getOffBy() == group)
-            {
-                voice->stopNoteForGroup();
-            }
-        }
-    }
-    
-    // Are any notes playing?  (Needed for first/legato trigger handling.)
-    // Also stop any voices still playing this note.
-    bool anyNotesPlaying = false;
-    for (i = voices.size(); --i >= 0;)
-    {
-        sfzero::Voice *voice = dynamic_cast<sfzero::Voice *>(voices.getUnchecked(i));
-        if (voice == nullptr)
-        {
-            continue;
-        }
-        if (voice->isPlayingChannel(midiChannel))
-        {
-            if (voice->isPlayingNoteDown())
-            {
-                if (voice->getCurrentlyPlayingNote() == midiNoteNumber)
-                {
-                    if (!voice->isPlayingOneShot())
-                    {
-                        voice->stopNoteQuick();
+            if (voice->isPlayingChannel(midiChannel)) {
+                if (voice->isPlayingNoteDown()) {
+                    if (voice->getCurrentlyPlayingNote() == midiNoteNumber) {
+                        if (!voice->isPlayingOneShot()) {
+                            voice->stopNoteQuick();
+                        }
+                    } else {
+                        anyNotesPlaying = true;
                     }
                 }
-                else
-                {
-                    anyNotesPlaying = true;
-                }
             }
         }
-    }
-    
-    // Play *all* matching regions.
-    sfzero::Region::Trigger trigger = (anyNotesPlaying ? sfzero::Region::legato : sfzero::Region::first);
-    if (sound)
-    {
-        int numRegions = sound->getNumRegions();
-        for (i = 0; i < numRegions; ++i)
-        {
-            sfzero::Region *region = sound->regionAt(i);
-            if (region->matches(midiNoteNumber, midiVelocity, trigger))
-            {
-                auto *voice = dynamic_cast<sfzero::Voice *>(findFreeVoice(sound, midiChannel, midiNoteNumber, isNoteStealingEnabled()));
-                if (voice)
-                {
-                    voice->setRegion(region);
-                    startVoice(voice, sound, midiChannel, midiNoteNumber, velocity);
-//                    DBG("noteON: " << midiNoteNumber << " " << midiChannel << " " << velocity);
-                }
-            }
-        }
-    }
 
-    noteVelocities_[midiNoteNumber] = midiVelocity;
+        // Play *all* matching regions.
+        sfzero::Region::Trigger trigger = (anyNotesPlaying ? sfzero::Region::legato : sfzero::Region::first);
+        if (sound) {
+            int numRegions = sound->getNumRegions();
+            for (i = 0; i < numRegions; ++i) {
+                sfzero::Region *region = sound->regionAt(i);
+                if (region->matches(midiNoteNumber, midiVelocity, trigger)) {
+                    auto *voice = dynamic_cast<sfzero::Voice *>(findFreeVoice(sound, midiChannel, midiNoteNumber,
+                                                                              isNoteStealingEnabled()));
+                    if (voice) {
+                        voice->setRegion(region);
+                        startVoice(voice, sound, midiChannel, midiNoteNumber, velocity);
+//                    DBG("noteON: " << midiNoteNumber << " " << midiChannel << " " << velocity);
+                    }
+                }
+            }
+        }
+
+        noteVelocities_[midiNoteNumber] = midiVelocity;
+
+    }
 }
 
 void sfzero::Synth::noteOff(int midiChannel, int midiNoteNumber, float velocity, bool allowTailOff)

--- a/MidiEditor.jucer
+++ b/MidiEditor.jucer
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="n64IQK" name="MidiEditor" projectType="guiapp" jucerVersion="5.4.7">
+<JUCERPROJECT id="n64IQK" name="MidiEditor" projectType="guiapp" jucerVersion="5.4.4">
   <MAINGROUP id="bseg78" name="MidiEditor">
     <GROUP id="{4D02D25C-6694-ABA1-B776-755A0F43BA73}" name="Source">
       <FILE id="jSDrYV" name="MainComponentK.cpp" compile="1" resource="0"

--- a/Source/Components/PlayerComponent.cpp
+++ b/Source/Components/PlayerComponent.cpp
@@ -45,7 +45,6 @@ void PlayerComponent::initSynth() {
         auto sounds = m_sfzLoader.getLoadedSounds();
         for (auto i=0; i<sounds.size(); i++) {
             auto * sound = sounds.getUnchecked(i).get();
-            sound->useSubsound(i);
             sound->setChannelNum(i);
             m_synth.addSound(sound);
         }

--- a/Source/Components/PlayerComponent.cpp
+++ b/Source/Components/PlayerComponent.cpp
@@ -39,9 +39,27 @@ void PlayerComponent::initSynth() {
 
     // Load sound from SoundFont file and add to synth.
     File * soundFontFile = new File(getAbsolutePathOfProject() + "/Resources/SoundFonts/GeneralUser GS 1.442 MuseScore/GeneralUser GS MuseScore v1.442.sf2");
-    m_sfzLoader.setSfzFile(soundFontFile);
-    std::function<void()> addLoadedSoundCallback = [this] () {m_synth.addSound(m_sfzLoader.getLoadedSound());};
-    m_sfzLoader.loadSound(true, &addLoadedSoundCallback);
+
+//    m_sfzLoader.setSfzFile(soundFontFile);
+//    std::function<void()> addLoadedSoundCallback = [this] () {
+//        std::cout << "Sound 0 Loaded: ch 0" << std::endl;
+//        auto * sound = m_sfzLoader.getLoadedSound();
+//        sound->useSubsound(0);
+//        sound->setChannelNum(3);
+//        m_synth.addSound(sound);
+//    };
+ //   m_sfzLoader.loadSound(true, &addLoadedSoundCallback);
+    //TODO: add ability to check through all available sounds in synth
+    m_sfzLoader1.setSfzFile(soundFontFile);
+    std::function<void()> addLoadedSoundCallback1 = [this] () {
+        std::cout << "Sound 40 Loaded: ch 3" << std::endl;
+        auto * sound = m_sfzLoader1.getLoadedSound();
+        sound->useSubsound(40);
+        sound->setChannelNum(3);
+        m_synth.addSound(sound);
+    };
+    m_sfzLoader1.loadSound(true, &addLoadedSoundCallback1);
+
 }
 
 void PlayerComponent::addMessageToBuffer(const MidiMessage& message) {

--- a/Source/Components/PlayerComponent.cpp
+++ b/Source/Components/PlayerComponent.cpp
@@ -40,23 +40,24 @@ void PlayerComponent::initSynth() {
     // Load sound from SoundFont file and add to synth.
     File * soundFontFile = new File(getAbsolutePathOfProject() + "/Resources/SoundFonts/GeneralUser GS 1.442 MuseScore/GeneralUser GS MuseScore v1.442.sf2");
 
-//    m_sfzLoader.setSfzFile(soundFontFile);
-//    std::function<void()> addLoadedSoundCallback = [this] () {
-//        std::cout << "Sound 0 Loaded: ch 0" << std::endl;
-//        auto * sound = m_sfzLoader.getLoadedSound();
-//        sound->useSubsound(0);
-//        sound->setChannelNum(3);
-//        m_synth.addSound(sound);
-//    };
- //   m_sfzLoader.loadSound(true, &addLoadedSoundCallback);
+    m_sfzLoader.setSfzFile(soundFontFile);
+    std::function<void()> addLoadedSoundCallback = [this] () {
+        auto * sound = m_sfzLoader.getLoadedSound();
+        sound->useSubsound(0);
+        sound->setChannelNum(8);
+        m_synth.addSound(sound);
+        std::cout << "Sound 0 Loaded: ch 8" << std::endl;
+    };
+    m_sfzLoader.loadSound(true, &addLoadedSoundCallback);
+
     //TODO: add ability to check through all available sounds in synth
     m_sfzLoader1.setSfzFile(soundFontFile);
     std::function<void()> addLoadedSoundCallback1 = [this] () {
-        std::cout << "Sound 40 Loaded: ch 3" << std::endl;
         auto * sound = m_sfzLoader1.getLoadedSound();
         sound->useSubsound(40);
         sound->setChannelNum(3);
         m_synth.addSound(sound);
+        std::cout << "Sound 40 Loaded: ch 3" << std::endl;
     };
     m_sfzLoader1.loadSound(true, &addLoadedSoundCallback1);
 

--- a/Source/Components/PlayerComponent.cpp
+++ b/Source/Components/PlayerComponent.cpp
@@ -42,24 +42,16 @@ void PlayerComponent::initSynth() {
 
     m_sfzLoader.setSfzFile(soundFontFile);
     std::function<void()> addLoadedSoundCallback = [this] () {
-        auto * sound = m_sfzLoader.getLoadedSound();
-        sound->useSubsound(0);
-        sound->setChannelNum(8);
-        m_synth.addSound(sound);
-        std::cout << "Sound 0 Loaded: ch 8" << std::endl;
+        auto sounds = m_sfzLoader.getLoadedSounds();
+        for (auto i=0; i<sounds.size(); i++) {
+            auto * sound = sounds.getUnchecked(i).get();
+            sound->useSubsound(i);
+            sound->setChannelNum(i);
+            m_synth.addSound(sound);
+        }
+        std::cout << sounds.size() << " sounds added." << std::endl;
     };
-    m_sfzLoader.loadSound(true, &addLoadedSoundCallback);
-
-    //TODO: add ability to check through all available sounds in synth
-    m_sfzLoader1.setSfzFile(soundFontFile);
-    std::function<void()> addLoadedSoundCallback1 = [this] () {
-        auto * sound = m_sfzLoader1.getLoadedSound();
-        sound->useSubsound(40);
-        sound->setChannelNum(3);
-        m_synth.addSound(sound);
-        std::cout << "Sound 40 Loaded: ch 3" << std::endl;
-    };
-    m_sfzLoader1.loadSound(true, &addLoadedSoundCallback1);
+    m_sfzLoader.loadSounds(kiNumChannels, true, &addLoadedSoundCallback);
 
 }
 

--- a/Source/Components/PlayerComponent.h
+++ b/Source/Components/PlayerComponent.h
@@ -93,6 +93,7 @@ private:
     SfzSynth m_synth;
 
     constexpr static int kiNumVoices = 24;
+    constexpr static int kiNumChannels = 16;
 
 
     //==============================================================================

--- a/Source/Components/PlayerComponent.h
+++ b/Source/Components/PlayerComponent.h
@@ -89,9 +89,10 @@ private:
     int m_iCurrentPosition = 0;
 
     SfzLoader m_sfzLoader;
+    SfzLoader m_sfzLoader1;
     SfzSynth m_synth;
 
-    constexpr static int kiNumVoices = 5;
+    constexpr static int kiNumVoices = 24;
 
 
     //==============================================================================

--- a/Source/Synth/SfzMidiSynth.cpp
+++ b/Source/Synth/SfzMidiSynth.cpp
@@ -17,7 +17,7 @@ SfzSynth::SfzSynth()
 }
 
 void SfzSynth::handleProgramChange(int iMidiChannel, int iProgram) {
-    std::cout<< "SfzSynth::handleProgramChange--> midiChannel: " << iMidiChannel << " programNumber: " << iProgram << std::endl;
+    DBG("SfzSynth::handleProgramChange--> midiChannel: " << iMidiChannel << " programNumber: " << iProgram);
     for (int s=0; s<getNumSounds(); s++) {
         auto *sound = getSound(s);
         if (sound->appliesToChannel(iMidiChannel)) {

--- a/Source/Synth/SfzMidiSynth.cpp
+++ b/Source/Synth/SfzMidiSynth.cpp
@@ -59,8 +59,9 @@ void SfzLoader::setSfzFile(File *pNewSfzFile)
 
 void SfzLoader::loadSounds(int iNumInstances /*= 1*/, bool bUseLoaderThread /*= false*/, std::function<void()> *callback /*= nullptr*/)
 {
-    m_callback = *callback;
     m_iNumInstances = iNumInstances;
+    if (callback)
+        m_callback = *callback;
     if (bUseLoaderThread) {
         m_loadThread.stopThread(2000);
         m_loadThread.startThread();

--- a/Source/Synth/SfzMidiSynth.cpp
+++ b/Source/Synth/SfzMidiSynth.cpp
@@ -39,7 +39,6 @@ sfzero::Sound * SfzSynth::getSound() const {
 }
 
 void SfzSynth::addSound(sfzero::Sound *sound) {
-    clearSounds();
     sfzero::Synth::addSound(sound);
 }
 

--- a/Source/Synth/SfzMidiSynth.h
+++ b/Source/Synth/SfzMidiSynth.h
@@ -31,10 +31,11 @@ private:
 class SfzLoader {
 public:
     SfzLoader();
+
     void setSfzFile(File *pNewSfzFile);
-    void loadSound(bool bUseLoaderThread = false, std::function<void()> *callback = nullptr);
+    void loadSounds(int iNumInstances = 1, bool bUseLoaderThread = false, std::function<void()> *callback = nullptr);
     double getLoadProgress() const;
-    sfzero::Sound * getLoadedSound() const;  // TODO: create factory for this and return new sound object every time.
+    ReferenceCountedArray<sfzero::Sound> getLoadedSounds() const;
 
 private:
     void load(Thread *pThread = nullptr);
@@ -46,12 +47,12 @@ private:
     private:
         SfzLoader *m_pSfzLoader;
     };
-    friend class LoadThread; //TODO: Is this required?? Why?
 
     File m_sfzFile;
     AudioFormatManager m_formatManager;
     LoadThread m_loadThread;
-    sfzero::Sound * m_pSound;
+    ReferenceCountedArray<sfzero::Sound> m_sounds;
     double m_fLoadProgress;
+    int m_iNumInstances;
     std::function<void()> m_callback;
 };


### PR DESCRIPTION
- `SfzLoader` is now able to load multiple sound object instances.
- 16 sounds are loaded and assigned to the synth, one for each channel.