### PR TITLE
Drum sounds and SfzSynth Refactor

### DIFF
--- a/Source/Components/PlayerComponent.cpp
+++ b/Source/Components/PlayerComponent.cpp
@@ -31,27 +31,8 @@ void PlayerComponent::resized()
 }
 
 void PlayerComponent::initSynth() {
-    m_synth.clearVoices();
-
-    for (int i=0; i < kiNumVoices; i++) {
-        m_synth.addVoice(new sfzero::Voice());
-    }
-
-    // Load sound from SoundFont file and add to synth.
     File * soundFontFile = new File(getAbsolutePathOfProject() + "/Resources/SoundFonts/GeneralUser GS 1.442 MuseScore/GeneralUser GS MuseScore v1.442.sf2");
-
-    m_sfzLoader.setSfzFile(soundFontFile);
-    std::function<void()> addLoadedSoundCallback = [this] () {
-        auto sounds = m_sfzLoader.getLoadedSounds();
-        for (auto i=0; i<sounds.size(); i++) {
-            auto * sound = sounds.getUnchecked(i).get();
-            sound->setChannelNum(i);
-            m_synth.addSound(sound);
-        }
-        std::cout << sounds.size() << " sounds added." << std::endl;
-    };
-    m_sfzLoader.loadSounds(kiNumChannels, true, &addLoadedSoundCallback);
-
+    m_synth.initSynth(soundFontFile);
 }
 
 void PlayerComponent::addMessageToBuffer(const MidiMessage& message) {

--- a/Source/Components/PlayerComponent.h
+++ b/Source/Components/PlayerComponent.h
@@ -90,13 +90,7 @@ private:
     PlayState m_playState = PlayState::Stopped;
     long m_iCurrentPosition = 0;
 
-    SfzLoader m_sfzLoader;
-    SfzLoader m_sfzLoader1;
     SfzSynth m_synth;
-
-    constexpr static int kiNumVoices = 24;
-    constexpr static int kiNumChannels = 16;
-
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PlayerComponent)

--- a/Source/Components/PlayerComponent.h
+++ b/Source/Components/PlayerComponent.h
@@ -90,7 +90,7 @@ private:
     PlayState m_playState = PlayState::Stopped;
     long m_iCurrentPosition = 0;
 
-    SfzSynth m_synth;
+    SoundFontGeneralMidiSynth m_synth;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PlayerComponent)

--- a/Source/Synth/SfzMidiSynth.cpp
+++ b/Source/Synth/SfzMidiSynth.cpp
@@ -17,26 +17,50 @@ SfzSynth::SfzSynth()
 }
 
 void SfzSynth::handleProgramChange(int iMidiChannel, int iProgram) {
-    DBG("SfzSynth::handleProgramChange--> midiChannel: " << iMidiChannel << " programNumber: " << iProgram);
-    for (int s=0; s<getNumSounds(); s++) {
-        auto *sound = getSound(s);
-        if (sound->appliesToChannel(iMidiChannel)) {
-            sound->useSubsound(iProgram);
-            return;
-        }
+    auto *sound = getSoundForChannel(iMidiChannel);
+    if (sound) {
+        sound->useSubsound(iProgram);
+        DBG("SfzSynth::handleProgramChange-->  midiChannel: " << iMidiChannel << "set to programNumber: " << iProgram);
     }
 }
 
 int SfzSynth::getProgramNumber(int iMidiChannel) const {
-    return getSound(iMidiChannel)->selectedSubsound();
+    sfzero::Sound * sound = getSoundForChannel(iMidiChannel);
+    if (sound)
+        return sound->selectedSubsound();
+    return -1;
 }
 
 juce::String SfzSynth::getProgramName(int iProgram) const {
-    return getSound(0)->subsoundName(iProgram);
+    sfzero::Sound * sound = getSoundForChannel(0);
+    if (sound)
+        return sound->subsoundName(iProgram);
+    return juce::String();
 }
 
-sfzero::Sound * SfzSynth::getSound(int iMidiChannel) const {
-    return dynamic_cast<sfzero::Sound *>(sfzero::Synth::getSound(iMidiChannel).get());
+void SfzSynth::setProgramNumber(int iProgramNum, int iMidiChannel) {
+    sfzero::Sound * sound = getSoundForChannel(iMidiChannel);
+    if (sound)
+        sound->useSubsound(iProgramNum);
+}
+
+void SfzSynth::resetProgramSelection() {
+    for (auto i=0; i<getNumSounds(); i++) {
+        if (i == kiPercussionChannelNum)
+            getSoundForChannel(i)->useSubsound(kiPercussionSubsoundNum);
+        else
+            getSoundForChannel(i)->useSubsound(0);
+    }
+}
+
+sfzero::Sound * SfzSynth::getSoundForChannel(int iMidiChannel) const {
+    for (int i=0; i<getNumSounds(); i++) {
+        auto *sound = dynamic_cast<sfzero::Sound *>(getSound(i).get());
+        if (sound->appliesToChannel(iMidiChannel)) {
+            return sound;
+        }
+    }
+    return nullptr;
 }
 
 void SfzSynth::addSound(sfzero::Sound *pSound) {
@@ -46,8 +70,6 @@ void SfzSynth::addSound(sfzero::Sound *pSound) {
 //============================================================================================================
 SfzLoader::SfzLoader() :
         m_loadThread(this),
-        m_fLoadProgress(0.0),
-        m_iNumInstances(0),
         m_callback(nullptr)
 {
 }

--- a/Source/Synth/SfzMidiSynth.cpp
+++ b/Source/Synth/SfzMidiSynth.cpp
@@ -10,20 +10,20 @@
 
 #include "SfzMidiSynth.h"
 
-SfzSynth::SfzSynth() :
+SoundFontGeneralMidiSynth::SoundFontGeneralMidiSynth() :
     m_sfzLoader(new SfzLoader())
 {
 }
 
-void SfzSynth::handleProgramChange(int iMidiChannel, int iProgram) {
+void SoundFontGeneralMidiSynth::handleProgramChange(int iMidiChannel, int iProgram) {
     auto *sound = getSoundForChannel(iMidiChannel);
     if (sound) {
         sound->useSubsound(iProgram);
-        DBG("SfzSynth::handleProgramChange-->  midiChannel: " << iMidiChannel << " set to programNumber: " << iProgram);
+        DBG("SoundFontGeneralMidiSynth::handleProgramChange-->  midiChannel: " << iMidiChannel << " set to programNumber: " << iProgram);
     }
 }
 
-void SfzSynth::initSynth(File * pSoundFontFile) {
+void SoundFontGeneralMidiSynth::initSynth(File * pSoundFontFile) {
     clearVoices();
     for (int i=0; i < kiNumVoices; i++) {
         addVoice(new sfzero::Voice());
@@ -46,27 +46,27 @@ void SfzSynth::initSynth(File * pSoundFontFile) {
     m_sfzLoader->loadSounds(kiNumChannels, true, &addLoadedSoundCallback);
 }
 
-int SfzSynth::getProgramNumber(int iMidiChannel) const {
+int SoundFontGeneralMidiSynth::getProgramNumber(int iMidiChannel) const {
     sfzero::Sound * sound = getSoundForChannel(iMidiChannel);
     if (sound)
         return sound->selectedSubsound();
     return -1;
 }
 
-juce::String SfzSynth::getProgramName(int iProgram) const {
+juce::String SoundFontGeneralMidiSynth::getProgramName(int iProgram) const {
     sfzero::Sound * sound = getSoundForChannel(0);
     if (sound)
         return sound->subsoundName(iProgram);
     return juce::String();
 }
 
-void SfzSynth::setProgramNumber(int iProgramNum, int iMidiChannel) {
+void SoundFontGeneralMidiSynth::setProgramNumber(int iProgramNum, int iMidiChannel) {
     sfzero::Sound * sound = getSoundForChannel(iMidiChannel);
     if (sound)
         sound->useSubsound(iProgramNum);
 }
 
-void SfzSynth::resetProgramSelection() {
+void SoundFontGeneralMidiSynth::resetProgramSelection() {
     for (auto i=0; i<getNumSounds(); i++) {
         if (i == kiPercussionChannelNum)
             getSoundForChannel(i)->useSubsound(kiPercussionSubSoundNum);
@@ -75,7 +75,7 @@ void SfzSynth::resetProgramSelection() {
     }
 }
 
-sfzero::Sound * SfzSynth::getSoundForChannel(int iMidiChannel) const {
+sfzero::Sound * SoundFontGeneralMidiSynth::getSoundForChannel(int iMidiChannel) const {
     for (int i=0; i<getNumSounds(); i++) {
         auto *sound = dynamic_cast<sfzero::Sound *>(getSound(i).get());
         if (sound->appliesToChannel(iMidiChannel)) {
@@ -85,7 +85,7 @@ sfzero::Sound * SfzSynth::getSoundForChannel(int iMidiChannel) const {
     return nullptr;
 }
 
-void SfzSynth::addSound(sfzero::Sound *pSound) {
+void SoundFontGeneralMidiSynth::addSound(sfzero::Sound *pSound) {
     sfzero::Synth::addSound(pSound);
 }
 

--- a/Source/Synth/SfzMidiSynth.h
+++ b/Source/Synth/SfzMidiSynth.h
@@ -14,10 +14,10 @@
 
 class SfzLoader;
 
-class SfzSynth : public sfzero::Synth
+class SoundFontGeneralMidiSynth : public sfzero::Synth
 {
 public:
-    SfzSynth();
+    SoundFontGeneralMidiSynth();
 
     void handleProgramChange (int iMidiChannel, int iProgram) override ;
 

--- a/Source/Synth/SfzMidiSynth.h
+++ b/Source/Synth/SfzMidiSynth.h
@@ -35,7 +35,7 @@ private:
     constexpr static int kiNumVoices = 24;
     constexpr static int kiNumChannels = 16;
     constexpr static int kiPercussionChannelNum = 10;
-    constexpr static int kiPercussionSubSoundNum = 24;
+    constexpr static int kiPercussionSubSoundNum = 247;
 };
 
 

--- a/Source/Synth/SfzMidiSynth.h
+++ b/Source/Synth/SfzMidiSynth.h
@@ -12,6 +12,8 @@
 
 #include "../../JuceLibraryCode/JuceHeader.h"
 
+class SfzLoader;
+
 class SfzSynth : public sfzero::Synth
 {
 public:
@@ -19,18 +21,21 @@ public:
 
     void handleProgramChange (int iMidiChannel, int iProgram) override ;
 
-    void addSound(sfzero::Sound *pSound);
+    void initSynth(File * pSoundFontFile);
     int getProgramNumber(int iMidiChannel) const;
     juce::String getProgramName(int iProgram) const;
     void setProgramNumber(int iProgramNum, int iMidiChannel);
     void resetProgramSelection();
 
-    sfzero::Sound * getSoundForChannel(int iMidiChannel) const;
 private:
+    void addSound(sfzero::Sound *pSound);
+    sfzero::Sound * getSoundForChannel(int iMidiChannel) const;
 
-
+    SfzLoader * m_sfzLoader;
+    constexpr static int kiNumVoices = 24;
+    constexpr static int kiNumChannels = 16;
     constexpr static int kiPercussionChannelNum = 10;
-    constexpr static int kiPercussionSubsoundNum = 24;
+    constexpr static int kiPercussionSubSoundNum = 24;
 };
 
 

--- a/Source/Synth/SfzMidiSynth.h
+++ b/Source/Synth/SfzMidiSynth.h
@@ -22,9 +22,15 @@ public:
     void addSound(sfzero::Sound *pSound);
     int getProgramNumber(int iMidiChannel) const;
     juce::String getProgramName(int iProgram) const;
+    void setProgramNumber(int iProgramNum, int iMidiChannel);
+    void resetProgramSelection();
 
+    sfzero::Sound * getSoundForChannel(int iMidiChannel) const;
 private:
-    sfzero::Sound * getSound(int iMidiChannel) const;
+
+
+    constexpr static int kiPercussionChannelNum = 10;
+    constexpr static int kiPercussionSubsoundNum = 24;
 };
 
 
@@ -52,7 +58,7 @@ private:
     AudioFormatManager m_formatManager;
     LoadThread m_loadThread;
     ReferenceCountedArray<sfzero::Sound> m_sounds;
-    double m_fLoadProgress;
-    int m_iNumInstances;
+    double m_fLoadProgress = 0.0;
+    int m_iNumInstances = 0;
     std::function<void()> m_callback;
 };


### PR DESCRIPTION
- `SfzSynth` renamed to `SoundFontGeneralMidiSynth`.
- Synth initialization logic moved from `PlayerComponent` to `SoundFontGeneralMidiSynth` class.
- Midi Channel 10 is initialized to use 'Synth Drums' subsound.